### PR TITLE
Prefer http/1.1 over h2 for tls

### DIFF
--- a/caddy/server.go
+++ b/caddy/server.go
@@ -143,13 +143,20 @@ func (c *caddyServer) buildConfig(apps []candy.App) *caddy.Config {
 	}
 
 	httpsServer := &caddyhttp.Server{
+		TLSConnPolicies: []*caddytls.ConnectionPolicy{
+			{
+				// Prefer http 1.1 over h2 in order: https://github.com/caddyserver/caddy/blob/792fca40f18b7c528b00a7dea508bdfd0821dd8c/modules/caddytls/connpolicy.go#L484
+				ALPN: []string{"http/1.1", "h2"},
+			},
+		},
 		Routes: caddyRoutes(
 			reverseproxy.HTTPTransport{
 				Versions: []string{"1.1", "2", "h2c"},
 			},
 			apps,
 		),
-		Listen: []string{c.cfg.HTTPSAddr},
+		Listen:   []string{c.cfg.HTTPSAddr},
+		AllowH2C: true,
 	}
 
 	// Best efforts of parsing corresponding port from addr


### PR DESCRIPTION
Prefer http/1.1 over h2 for tls. This helps with h2c on https